### PR TITLE
Fix wrong variable name

### DIFF
--- a/ost_wbs/classes/class.ticket.php
+++ b/ost_wbs/classes/class.ticket.php
@@ -150,7 +150,7 @@ class Ticket
             $numRows = $getTickets->num_rows;
             
             // Fetch data
-            while($PrintTickets = $getTickets->fetch_object()){ array_push($ownTicket, self::compileResults($PrintTickets)); }
+            while($PrintTickets = $getTickets->fetch_object()){ array_push($result, self::compileResults($PrintTickets)); }
         
             // Check if there are some results in the array
             if(!$result){


### PR DESCRIPTION
The function to get a specific ticket was broken because it was using the wrong variable to gather the results of the database query.