### PR TITLE
Added GET tickets by last updated date

### DIFF
--- a/ost_wbs/classes/class.ticket.php
+++ b/ost_wbs/classes/class.ticket.php
@@ -64,6 +64,17 @@ class Ticket
                     $getTickets = $mysqli->query("SELECT * FROM ".TABLE_PREFIX."ticket INNER JOIN ".TABLE_PREFIX."ticket__cdata ON ".TABLE_PREFIX."ticket.ticket_id = ".TABLE_PREFIX."ticket__cdata.ticket_id INNER JOIN ".TABLE_PREFIX."thread_entry ON ".TABLE_PREFIX."ticket.ticket_id = ".TABLE_PREFIX."thread_entry.thread_id WHERE ".TABLE_PREFIX."ticket.created >= '$startDate' and ".TABLE_PREFIX."ticket.created <= '$endDate'");
 
                 break;
+                // Sorte by Last Update Date
+                case "lastUpdateDate":
+
+                    // Get Start&End Date
+                    $startDate = $parameters['parameters']['start_date'];
+                    $endDate = $parameters['parameters']['end_date'];
+
+                    // Query
+                    $getTickets = $mysqli->query("SELECT * FROM ".TABLE_PREFIX."ticket INNER JOIN ".TABLE_PREFIX."ticket__cdata ON ".TABLE_PREFIX."ticket.ticket_id = ".TABLE_PREFIX."ticket__cdata.ticket_id INNER JOIN ".TABLE_PREFIX."thread_entry ON ".TABLE_PREFIX."ticket.ticket_id = ".TABLE_PREFIX."thread_entry.thread_id WHERE ".TABLE_PREFIX."ticket.lastupdate >= '$startDate' and ".TABLE_PREFIX."ticket.lastupdate <= '$endDate'");
+
+                break;
                 // Sorte by Status
                 case "status":
 

--- a/ost_wbs/classes/class.ticket.php
+++ b/ost_wbs/classes/class.ticket.php
@@ -72,7 +72,7 @@ class Ticket
                     $endDate = $parameters['parameters']['end_date'];
 
                     // Query
-                    $getTickets = $mysqli->query("SELECT * FROM ".TABLE_PREFIX."ticket INNER JOIN ".TABLE_PREFIX."ticket__cdata ON ".TABLE_PREFIX."ticket.ticket_id = ".TABLE_PREFIX."ticket__cdata.ticket_id INNER JOIN ".TABLE_PREFIX."thread_entry ON ".TABLE_PREFIX."ticket.ticket_id = ".TABLE_PREFIX."thread_entry.thread_id WHERE ".TABLE_PREFIX."ticket.lastupdate >= '$startDate' and ".TABLE_PREFIX."ticket.lastupdate <= '$endDate'");
+                    $getTickets = $mysqli->query("SELECT * FROM ".TABLE_PREFIX."ticket INNER JOIN ".TABLE_PREFIX."ticket__cdata ON ".TABLE_PREFIX."ticket.ticket_id = ".TABLE_PREFIX."ticket__cdata.ticket_id INNER JOIN ".TABLE_PREFIX."thread ON ".TABLE_PREFIX."thread.object_id = ".TABLE_PREFIX."ticket.ticket_id INNER JOIN ".TABLE_PREFIX."thread_entry ON ".TABLE_PREFIX."thread.id = ".TABLE_PREFIX."thread_entry.thread_id WHERE ".TABLE_PREFIX."ticket.lastupdate >= '$startDate' and ".TABLE_PREFIX."ticket.lastupdate <= '$endDate'");
 
                 break;
                 // Sorte by Status


### PR DESCRIPTION
Thank you for this excellent API! It's a great addition to osTicket and I appreciate your hard work on it.

I wanted to use an API to find all tickets that were last modified between two dates. 

It is the same as getting tickets [by creation date](https://bmsvieira.gitbook.io/osticket-api/ticket/get-creation-date), but this uses when the ticket was last updated/modified.

The database column to sort by is `lastupdate`, instead of `created`.